### PR TITLE
Add github to check and automatically update the Zarf Injector component upon renovate execution (or other PR)

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,14 +1,10 @@
 name: release
 
-# triggered when a push is made to the main branch AND either zarf.yaml or zarf-config.yaml are modified
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - "zarf.yaml"
-      - "zarf-config.yaml"
-  workflow_dispatch:
+  workflow_run:
+    workflows: ["Zarf Injector Update"] # Name of the Zarf injector workflow
+    types:
+      - completed
 
 jobs:
   release:
@@ -34,8 +30,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: registry1.dso.mil
-          username: ${{ secrets.IRONBANK_USERNAME }}
-          password: ${{ secrets.IRONBANK_PASSWORD }}
+          username: ${{ secrets.IRON_BANK_ROBOT_USERNAME }}
+          password: ${{ secrets.IRON_BANK_ROBOT_PASSWORD }}
       - name: Install Zarf
         uses: defenseunicorns/setup-zarf@main
         with:

--- a/.github/workflows/update-zarf-injector.yaml
+++ b/.github/workflows/update-zarf-injector.yaml
@@ -1,0 +1,89 @@
+name: Zarf Injector Update
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "zarf.yaml"
+      - "zarf-config.yaml"
+  workflow_dispatch:
+
+jobs:
+  update-injector-version:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+
+      - name: Log zarf-config.yaml contents
+        run: |
+          echo "Logging contents of zarf-config.yaml:"
+          cat zarf-config.yaml
+
+      - name: Extract Zarf version (agent_image_tag)
+        id: zarf_version
+        run: |
+          zarf_version=$(grep 'agent_image_tag:' zarf-config.yaml | awk '{print $2}' | tr -d ' ')
+          if [ -z "$zarf_version" ]; then
+            echo "Error: Zarf version (agent_image_tag) not found in zarf-config.yaml"
+            exit 1
+          fi
+
+          echo "Zarf Release Version: $zarf_version"
+          echo "zarf_version=$zarf_version" >> $GITHUB_ENV
+
+      - name: Clone zarf-dev repository and checkout version
+        run: |
+          git clone https://github.com/zarf-dev/zarf.git
+          cd zarf
+
+          git fetch --all --tags
+
+          if git rev-parse "${{ env.zarf_version }}" >/dev/null 2>&1; then
+            git checkout "${{ env.zarf_version }}"
+          else
+            echo "Error: Release version ${{ env.zarf_version }} not found in zarf-dev repository."
+            exit 1
+          fi
+
+          cp zarf-config.toml ../
+          cd ..
+
+      - name: Parse and update zarf-config.yaml
+        run: |
+          # Extract values from the zarf-config.toml file
+          version=$(grep 'injector_version =' zarf-config.toml | cut -d"'" -f2)
+          amd64_shasum=$(grep 'injector_amd64_shasum =' zarf-config.toml | cut -d"'" -f2)
+          arm64_shasum=$(grep 'injector_arm64_shasum =' zarf-config.toml | cut -d"'" -f2)
+
+          # Log extracted values (optional for debugging)
+          echo "Injector Version: $version"
+          echo "Injector AMD64 SHA: $amd64_shasum"
+          echo "Injector ARM64 SHA: $arm64_shasum"
+
+          # Update the local zarf-config.yaml file with these values
+          sed -i "s/injector_version: .*/injector_version: \"$version\"/" zarf-config.yaml
+          sed -i "s/injector_amd64_shasum: .*/injector_amd64_shasum: $amd64_shasum/" zarf-config.yaml
+          sed -i "s/injector_arm64_shasum: .*/injector_arm64_shasum: $arm64_shasum/" zarf-config.yaml
+
+      - name: Check for changes
+        id: git_status
+        run: |
+          if git diff --quiet; then
+            echo "No changes detected."
+            echo "changes=false" >> $GITHUB_ENV
+          else
+            echo "Changes detected."
+            echo "changes=true" >> $GITHUB_ENV
+          fi
+
+      - name: Commit and push changes
+        if: env.changes == 'true'
+        run: |
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "GitHub Actions Bot"
+          git add zarf-config.yaml
+          git commit -m "Update Zarf injector version and shasums from zarf-config.toml"
+          git push

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: check-added-large-files
         args: ["--maxkb=1024"]
@@ -22,6 +22,6 @@ repos:
     hooks:
       - id: fix-smartquotes
   - repo: https://github.com/renovatebot/pre-commit-hooks
-    rev: 38.110.1
+    rev: 38.110.2
     hooks:
       - id: renovate-config-validator

--- a/renovate.json5
+++ b/renovate.json5
@@ -20,13 +20,14 @@
   // If we don't specify a timezone then Renovate will use UTC
   "timezone": "America/New_York",
   "schedule": ["at any time"],
+  "postUpdateOptions": [
+    "git-push"  // Ensure Renovate pushes its changes after updating
+  ],
   // Using a value of "conflicted" means that Renovate will only rebase PRs if they are in a conflicted state. See https://docs.renovatebot.com/configuration-options/#rebasewhen
   "rebaseWhen": "auto",
   // Labels to set in Pull Request. See https://docs.renovatebot.com/configuration-options/#labels
-  "labels": [
-    "renovate"
-  ],
-  // Rate limit PRs to maximum x created per hour. 0 means no limit. See https://docs.renovatebot.com/configuration-options/#prhourlylimit
+  "labels": ["renovate"],
+   // Rate limit PRs to maximum x created per hour. 0 means no limit. See https://docs.renovatebot.com/configuration-options/#prhourlylimit
   "prHourlyLimit": 0,
   // Limit to a maximum of x concurrent branches/PRs. 0 means no limit. See https://docs.renovatebot.com/configuration-options/#prconcurrentlimit
   "prConcurrentLimit": 0,
@@ -35,7 +36,7 @@
     "enabled": true
   },
   "regexManagers": [
-    // Custom regex manager for the .env file that follows the pattern documented here: https://docs.renovatebot.com/modules/manager/regex/#advanced-capture
+   // Custom regex manager for the .env file that follows the pattern documented here: https://docs.renovatebot.com/modules/manager/regex/#advanced-capture
     {
       "fileMatch": [
         "(^|/)zarf(-.+)?\\.ya?ml$", // Matches "zarf*.yaml" and "zarf*.yml"
@@ -53,11 +54,11 @@
   ],
   "hostRules": [
     {
-        "matchHost": "registry1.dso.mil",
-        "hostType": "docker",
-        "description": "Encrypted creds for registry1, scoped to this Github org using: https://docs.renovatebot.com/getting-started/migrating-secrets/#migrate-your-secrets-in-encrypted-form",
-        "username": "{{ secrets.IRONBANK_USERNAME }}",
-        "password": "{{ secrets.IRONBANK_PASSWORD }}"
+      "matchHost": "registry1.dso.mil",
+      "hostType": "docker",
+      "description": "Encrypted creds for registry1, scoped to this Github org using: https://docs.renovatebot.com/getting-started/migrating-secrets/#migrate-your-secrets-in-encrypted-form",
+      "username": "{{ secrets.IRONBANK_USERNAME }}",
+      "password": "{{ secrets.IRONBANK_PASSWORD }}"
     }
   ],
   "vulnerabilityAlerts": {

--- a/zarf-config.yaml
+++ b/zarf-config.yaml
@@ -9,9 +9,9 @@ package:
       agent_image_tag: v0.41.0
 
       # Tag for the zarf injector binary to use
-      injector_version: "2024-05-15"
-      injector_amd64_shasum: 1b34519ac30daf0e5a4a2f0a0766dbcd0852c0b5364b35576eea4ac9e22d9e82
-      injector_arm64_shasum: ca20f427f9cf91ff42646a785c4772be5892a6752fa14924c5085b2d0109b008
+      injector_version: "2024-07-22"
+      injector_amd64_shasum: 8463bfd66930a4b26c665b51f25e8a32ed5948068bae49987013c89173394478
+      injector_arm64_shasum: b905e647e0d7876cfd5b665632cfc43ad919dc60408f7236c5b541c53277b503
 
       # The image reference to use for the registry that Zarf deploys into the cluster
       registry_image_domain: ""


### PR DESCRIPTION
Was messing with renovate and other tooling to see if I could get the Zarf injector to update automatically. Since the file change is in the zarf-config.toml file upstream and not in the release itself or tagging, there's nothing I think renovate can do. So, I think a Github action to pull the file and check is still a decent option. I forked the repo and tested it by changing the values and watching the action change it back on the push to main.