### PR TITLE
chore: Refactor injector update and release logic for renovate

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,16 +1,17 @@
 name: release
 
 on:
-  workflow_run:
-    workflows: ["Zarf Injector Update"] # Name of the Zarf injector workflow
-    types:
-      - completed
+  push:
+    branches:
+      - main
+    paths:
+      - "zarf.yaml"
+      - "zarf-config.yaml"
 
 jobs:
   release:
     runs-on: ubuntu-latest
     permissions:
-      # id-token: write # needed for keyless signing
       contents: read
       packages: write # needed for ghcr access
     strategy:

--- a/.github/workflows/update-zarf-injector.yaml
+++ b/.github/workflows/update-zarf-injector.yaml
@@ -1,18 +1,23 @@
 name: Zarf Injector Update
 
 on:
-  push:
-    branches:
-      - main
+  pull_request:
     paths:
       - "zarf.yaml"
       - "zarf-config.yaml"
+    branches:
+      - "main"
   workflow_dispatch:
 
 jobs:
   update-injector-version:
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
-
+    if:
+      # if this workflow is triggered by renovate bot
+      github.actor == 'renovate[bot]'
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4
@@ -79,11 +84,10 @@ jobs:
             echo "changes=true" >> $GITHUB_ENV
           fi
 
-      - name: Commit and push changes
+      - name: Sign and push changes using graphql
         if: env.changes == 'true'
-        run: |
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git config --global user.name "GitHub Actions Bot"
-          git add zarf-config.yaml
-          git commit -m "Update Zarf injector version and shasums from zarf-config.toml"
-          git push
+        uses: planetscale/ghcommit-action@v0.2.0
+        with:
+          commit_message: "Update Zarf injector version and shasums from upstream"
+          repo: ${{ github.repository }}
+          branch: ${{ github.head_ref || github.ref_name }}

--- a/renovate.json5
+++ b/renovate.json5
@@ -5,6 +5,7 @@
   "ignoreTests": true,
   "baseBranches": ["main"],
   "extends": [
+    "github>defenseunicorns/narwhal-delivery-renovate-config:hostRules_registry1.json5",
     // Tells Renovate to maintain one GitHub issue as the "dependency dashboard". See https://docs.renovatebot.com/key-concepts/dashboard
     ":dependencyDashboard",
     // Use semantic commit type fix for dependencies and chore for all others if semantic commits are in use. See https://docs.renovatebot.com/presets-default/#semanticprefixfixdepschoreothers
@@ -50,15 +51,6 @@
         "datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s.*?init:(?<currentValue>[^\\s]+)\\s" // https://regex101.com/r/ZpKhgH/1 - updating init package import based on zarf-agent version in registry1
       ],
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
-    }
-  ],
-  "hostRules": [
-    {
-      "matchHost": "registry1.dso.mil",
-      "hostType": "docker",
-      "description": "Encrypted creds for registry1, scoped to this Github org using: https://docs.renovatebot.com/getting-started/migrating-secrets/#migrate-your-secrets-in-encrypted-form",
-      "username": "{{ secrets.IRONBANK_USERNAME }}",
-      "password": "{{ secrets.IRONBANK_PASSWORD }}"
     }
   ],
   "vulnerabilityAlerts": {


### PR DESCRIPTION
This pull request addresses:

1. Refactor of logic to update zarf-inector version + SHA. This will now only trigger if `renovate[bot]` [is the actor](https://github.com/defenseunicorns/delivery-zarf-init/blob/fix/use-graphql-for-commits/.github/workflows/update-zarf-injector.yaml#L18-L20) triggering the workflow in a PR. By default, this will get triggered on pull-request open, synchronize (pushes to head), and reopens specifically if the actor is renovate. Additionally, logic has been added to sign the commits in the pipeline, you have to use graphql to do this and luckily someone else [made an action ](https://github.com/defenseunicorns/delivery-zarf-init/blob/fix/use-graphql-for-commits/.github/workflows/update-zarf-injector.yaml#L87-L93)to do this for us.
2. Update the renovate config to use the extended settings for `hostRules`